### PR TITLE
Ensure the installer directory is deleted

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,5 +59,8 @@ roundcube_dependencies:
 # carddav
 roundcube_carddav_version: 4.4.2
 
+# Installer
+roundcube_installer_delete: true
+
 # Apache
 roundcube_apache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,3 +140,9 @@
   when: "'getmail' in roundcube_plugins"
   tags:
     - getmail
+
+- name: Ensure the installer directory is deleted
+  file:
+    path: "{{ roundcube_user_home }}/roundcubemail-{{ roundcube_version }}/installer"
+    state: absent
+  when: roundcube_installer_delete | bool


### PR DESCRIPTION
As per the docs, it is important to delete the installer folder after the installation is finished. Therefore keeping the installer dir after might be a security risk.

https://github.com/roundcube/roundcubemail/blob/master/INSTALL#L59