### PR TITLE
Check if roundcube directory exists, Unarchive if it does not exist.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,11 @@
   import_tasks: mcrypt.yml
   when: ansible_distribution_major_version|int > 9
 
+- name: Check if roundcube directory exists
+  stat:
+    path: "{{ roundcube_user_home }}/roundcubemail-{{ roundcube_version }}"
+  register: "roundcube_directory"
+
 - name: Get roundcube release
   get_url:
     url: "https://github.com/roundcube/roundcubemail/releases/download/{{ roundcube_version }}/roundcubemail-{{ roundcube_version }}-complete.tar.gz"
@@ -66,7 +71,7 @@
     group: "{{ roundcube_group }}"
     mode: 0750
     copy: no
-  when: download.changed
+  when: (download.changed) or (not roundcube_directory.stat.exists)
 
 - name: Link to current release
   file:


### PR DESCRIPTION
Somehow when testing this role I ended up without the roundcube dir but with the archive file present. I got this error

```
TASK [systemli.roundcube : Link to current release] ***************************************************************************************************************************************************************
fatal: [xxx]: FAILED! => {"changed": false, "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /var/www/clients/client1/web17/web/roundcubemail-1.6.1/", "path": "/var/www/clients/client1/web17/web/www", "src": "/var/www/clients/client1/web17/web/roundcubemail-1.6.1/"}
```

This PR fixes that.