### PR TITLE
Introduce roundcube_working_dir variable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,8 @@ roundcube_user: roundcube
 roundcube_group: roundcube
 roundcube_user_shell: /bin/false
 roundcube_user_home: "/var/www/{{ roundcube_domain }}"
-roundcube_path: "{{ roundcube_user_home }}/www"
+roundcube_working_dir: "{{ roundcube_user_home }}"
+roundcube_path: "{{ roundcube_working_dir }}/www"
 roundcube_mysql_user: roundcube
 roundcube_mysql_password: "{{ roundcube_mysql_password_enc }}"
 roundcube_mysql_db: roundcubemail
@@ -40,7 +41,7 @@ roundcube_configs_extra:
 
 # enigma plugin settings
 roundcube_enigma_password_time: 5
-roundcube_enigma_home: "{{ roundcube_user_home }}/enigma/home"
+roundcube_enigma_home: "{{ roundcube_working_dir }}/enigma/home"
 roundcube_enigma_open_basedirs:
   - "/usr/bin/gpg"
   - "/usr/bin/gpg-agent"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
 - name: Get roundcube release
   get_url:
     url: "https://github.com/roundcube/roundcubemail/releases/download/{{ roundcube_version }}/roundcubemail-{{ roundcube_version }}-complete.tar.gz"
-    dest: "{{ roundcube_user_home }}"
+    dest: "{{ roundcube_working_dir }}"
     owner: "{{ roundcube_user }}"
     group: "{{ roundcube_group }}"
     mode: '0440'
@@ -60,8 +60,8 @@
 
 - name: Unarchive roundcube
   unarchive:
-    src: "{{ roundcube_user_home }}/roundcubemail-{{ roundcube_version }}-complete.tar.gz"
-    dest: "{{ roundcube_user_home }}"
+    src: "{{ roundcube_working_dir }}/roundcubemail-{{ roundcube_version }}-complete.tar.gz"
+    dest: "{{ roundcube_working_dir }}"
     owner: "{{ roundcube_user }}"
     group: "{{ roundcube_group }}"
     mode: 0750
@@ -70,7 +70,7 @@
 
 - name: Link to current release
   file:
-    src: "{{ roundcube_user_home }}/roundcubemail-{{ roundcube_version }}/"
+    src: "{{ roundcube_working_dir }}/roundcubemail-{{ roundcube_version }}/"
     dest: "{{ roundcube_path }}"
     owner: "{{ roundcube_user }}"
     group: "{{ roundcube_group }}"
@@ -143,6 +143,6 @@
 
 - name: Ensure the installer directory is deleted
   file:
-    path: "{{ roundcube_user_home }}/roundcubemail-{{ roundcube_version }}/installer"
+    path: "{{ roundcube_working_dir }}/roundcubemail-{{ roundcube_version }}/installer"
     state: absent
   when: roundcube_installer_delete | bool


### PR DESCRIPTION
My Control Panel by default sets the user home dir to a different location than `roundcube_user_home` so every time I run this role it sets it to `roundcube_user_home` and then the Control Panel changes it back. This PR fixes this.