### PR TITLE
Fix: Check if roundcube directory exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
 
 - name: Check if roundcube directory exists
   stat:
-    path: "{{ roundcube_user_home }}/roundcubemail-{{ roundcube_version }}"
+    path: "{{ roundcube_working_dir }}/roundcubemail-{{ roundcube_version }}"
   register: "roundcube_directory"
 
 - name: Get roundcube release


### PR DESCRIPTION
This patch fixes the path. otherwise, on my system, this test always returns false. On your system, this change makes no impact.