### PR TITLE
Make the skin deployment deterministic

### DIFF
--- a/tasks/skin.yml
+++ b/tasks/skin.yml
@@ -2,10 +2,13 @@
 
 - name: Create custom skin dir for elastic skin
   ansible.posix.synchronize:
-    src: "{{ roundcube_skin }}"
+    archive: false
+    checksum: true
     dest: "{{ roundcube_working_dir }}/current/skins/"
-    owner: false
     group: false
+    owner: false
+    recursive: true
+    src: "{{ roundcube_skin }}"
   when: roundcube_skin == 'elastic_systemli'
 
 - name: Ensure custom skin dir has correct permissions


### PR DESCRIPTION
Before, the code implicitly relied on `archive`, which defaults to `true` and implies:

```
Mirrors the rsync archive flag, enables recursive, links, perms, times, owner, group flags and -D.
```

This made the deployment nondeterministic in environments which rely on git, as that doesn't track times: results would be bound to the fact *when* a git checkout happened.

This change ignores times, via `archive` set to `false`. Instead, it relies on `checksum`, which is reliable. Besides, `recursive` is set to `true` explicitly, to mirror the former behaviour.